### PR TITLE
increased vliqEntries and vlissqEntries to avoid hiccups in op_macc v…

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -49,6 +49,7 @@ bmarks = \
 	vec-square-root-approx \
 	vec-transpose-load \
 	vec-transpose-store \
+	opu-sq-gemm \
 	vec-optest
 
 cpp_bmarks = \

--- a/benchmarks/opu-sq-gemm/bme.h
+++ b/benchmarks/opu-sq-gemm/bme.h
@@ -1,0 +1,58 @@
+// HACK reuse the scalar registers to avoid assembler hacking for now
+#define m0 "x0"
+#define m1 "x1"
+#define m2 "x2"
+#define m3 "x3"
+#define m4 "x4"
+#define m5 "x5"
+#define m6 "x6"
+#define m7 "x7"
+
+#define v0 "x0"
+#define v1 "x1"
+#define v2 "x2"
+#define v3 "x3"
+#define v4 "x4"
+#define v5 "x5"
+#define v6 "x6"
+#define v7 "x7"
+#define v8 "x8"
+#define v9 "x9"
+#define v10 "x10"
+#define v11 "x11"
+#define v12 "x12"
+#define v13 "x13"
+#define v14 "x14"
+#define v15 "x15"
+#define v16 "x16"
+#define v17 "x17"
+#define v18 "x18"
+#define v19 "x19"
+#define v20 "x20"
+#define v21 "x21"
+#define v22 "x22"
+#define v23 "x23"
+#define v24 "x24"
+#define v25 "x25"
+#define v26 "x26"
+#define v27 "x27"
+#define v28 "x28"
+#define v29 "x29"
+#define v30 "x30"
+#define v31 "x31"
+
+// opmvx. f6=b101010, f7=b1010101
+#define VMV_RV(md, rs1, vs2) \
+  asm volatile(".insn r 0x57, 0x6, 0x55, " md ", %0, " vs2 : : "r"(rs1));
+
+// opmvx. f6=b101110, f7=b1011101
+#define VMV_VR(vd, rs1, ms2) \
+  asm volatile(".insn r 0x57, 0x6, 0x5d, " vd ", %0, " ms2 : : "r"(rs1));
+
+// opmvx. f6=b101100, f7=b1011001
+#define OPMVINBCAST(md, vs2) \
+  asm volatile(".insn r 0x57, 0x6, 0x59, " md ", x0, " vs2);
+
+// opmvv. f6=b101000, f7=b1010001
+#define VOPACC(md, vs2, vs1) \
+  asm volatile(".insn r 0x57, 0x2, 0x51, " md ", " vs1 ", " vs2);

--- a/benchmarks/opu-sq-gemm/square-igemm.c
+++ b/benchmarks/opu-sq-gemm/square-igemm.c
@@ -1,0 +1,217 @@
+#include <stdio.h>
+#include <riscv-pk/encoding.h>
+#include <riscv_vector.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "bme.h"
+
+#define STR1(x) #x
+#ifndef STR
+#define STR(x) STR1(x)
+#endif
+
+void i8_mm_scalar(int32_t* c_in, int32_t* c_out, int8_t* at, int8_t* b, size_t M, size_t N, size_t K) {
+    for (size_t i = 0; i < M; i++) {
+      for (size_t j = 0; j < N; j++) {
+        c_out[i*N+j] = c_in[i*N+j];
+        for (size_t k = 0; k < K; k++) {
+          c_out[i*N+j] += at[k*M+i] * b[k*N+j];
+        }
+      }
+    }
+  }
+
+void i32_load_c(int* c, size_t ml, size_t N) {
+  for (size_t r = 0; r < ml; r++) {
+    asm volatile("vle32.v v0, (%0)" : : "r"(&c[r*N]));
+    VMV_RV(m4, r, v0); // move v0 into row r of m4
+  }
+}
+
+void i32_store_c(int* c, size_t ml, size_t N) {
+  for (size_t r = 0; r < ml; r++) {
+    VMV_VR(v0, r, m4); // move row r of m4 into v0
+    asm volatile("vse32.v v0, (%0)" : : "r"(&c[r*N]));
+  }
+}
+
+void i8_loop_k_general(int8_t* at, int8_t* b, size_t M, size_t N, size_t K, size_t ml, size_t vl) {
+    for (size_t k = 0; k < K; k++) {
+        asm volatile("vsetvli zero, %0, e8, m1, ta, ma" : : "r"(ml));
+        asm volatile("vle8.v v0, (%0)" : : "r"(&at[k*M]));
+        asm volatile("vsetvli zero, %0, e8, m1, ta, ma" : : "r"(vl));
+        asm volatile("vle8.v v8, (%0)" : : "r"(&b[k*N]));
+        VOPACC(m4, v8, v0);
+        // vopacc md=m4, vs2=v0, vs1=v8
+    }
+}
+  
+void i8_loop_k_square(int8_t* at, int8_t* b, size_t M, size_t N, size_t K) {
+  size_t k;
+  for (k = 0; k+4 <= K; k+=4) {
+    asm volatile("vle8.v v4, (%0)" : : "r"(&at[k*M]));
+    asm volatile("vle8.v v16, (%0)" : : "r"(&b[k*N]));
+    VOPACC(m4, v16, v4);
+
+    asm volatile("vle8.v v5, (%0)" : : "r"(&at[(k+1)*M]));
+    asm volatile("vle8.v v17, (%0)" : : "r"(&b[(k+1)*N]));
+    VOPACC(m4, v17, v5);
+
+    asm volatile("vle8.v v6, (%0)" : : "r"(&at[(k+2)*M]));
+    asm volatile("vle8.v v18, (%0)" : : "r"(&b[(k+2)*N]));
+    VOPACC(m4, v18, v6);
+
+    asm volatile("vle8.v v7, (%0)" : : "r"(&at[(k+3)*M]));
+    asm volatile("vle8.v v19, (%0)" : : "r"(&b[(k+3)*N]));
+    VOPACC(m4, v19, v7);
+}
+// for (k; k < K; k++) {
+//   asm volatile("vle8.v v0, (%0)" : : "r"(&at[k*M]));
+//   asm volatile("vle8.v v8, (%0)" : : "r"(&b[k*N]));
+//   VOPACC(m4, v8, v0);
+//   // vopacc md=m4, vs2=v0, vs1=v8
+// }
+}
+
+void i8_mm_bme_square(int32_t* c_in, int32_t* c_out, int8_t* at, int8_t* b, size_t M, size_t N, size_t K) {
+  size_t vlenb ;
+  asm volatile("vsetvli %0, zero, e8, m1, ta, ma" : "=r"(vlenb));
+  size_t mlmax = vlenb;
+
+  size_t vl;
+//   asm volatile("vsetvli %0, zero, e32, m4, ta, ma" : "=r"(vl));
+  size_t i = 0;
+  while (i + mlmax <= M) {
+    size_t j = 0;
+
+    while (j + mlmax <= N) {
+      asm volatile("vsetvli zero, %0, e32, m4, ta, ma" : : "r"(mlmax));
+      i32_load_c(&c_in[(i*N)+j], mlmax, N);
+      asm volatile("vsetvli zero, %0, e8, m1, ta, ma" : : "r"(mlmax));
+      i8_loop_k_square(&at[i], &b[j], M, N, K);
+      asm volatile("vsetvli zero, %0, e32, m4, ta, ma" : : "r"(mlmax));
+      i32_store_c(&c_out[(i*N)+j], mlmax, N);
+      j += mlmax;
+    }
+
+    while (j < N) {
+      asm volatile("vsetvli %0, %1, e32, m4, ta, ma" : "=r"(vl) : "r"(N - j));
+      i32_load_c(&c_in[(i*N)+j], mlmax, N);
+      i8_loop_k_general(&at[i], &b[j], M, N, K, mlmax, vl);
+      asm volatile("vsetvli zero, %0, e32, m4, ta, ma" : : "r"(vl));
+      i32_store_c(&c_out[(i*N)+j], mlmax, N);
+      j += vl;
+    }
+    i += mlmax;
+  }
+  
+  while (i < M) {
+    size_t remaining = M - i;
+    size_t ml = remaining > mlmax ? mlmax : remaining;
+
+    for (size_t j = 0; j < N;) {
+      asm volatile("vsetvli %0, %1, e32, m4, ta, ma" : "=r"(vl) : "r"(N - j));
+      i32_load_c(&c_in[(i*N)+j], ml, N);
+
+      i8_loop_k_general(&at[i], &b[j], M, N, K, ml, vl);
+
+      asm volatile("vsetvli zero, %0, e32, m4, ta, ma" : : "r"(vl));
+      i32_store_c(&c_out[(i*N)+j], ml, N);
+      j += vl;
+    }
+    i += ml;
+  }
+}
+
+void i32_init(int* d, size_t s) {
+  for (size_t i = 0; i < s; i++) {
+    d[i] = i + 1;
+  }
+}
+
+void i8_init(int8_t* d, size_t s, int8_t start) {
+    for (size_t i = 0; i < s; i++) {
+      d[i] = start + i;
+    }
+  }
+  
+int i32_compare(int32_t* a, int32_t* b, size_t m, size_t n) {
+    for (size_t i = 0; i < m; i++) {
+      for (size_t j = 0; j < n; j++) {
+        size_t index = i * n + j;
+        if (a[index] != b[index]) {
+          printf("DIVERGENCE at index (%ld, %ld): 0x%x != 0x%x\n", i, j, a[index], b[index]);
+          return 1;
+        }
+      }
+    }
+    return 0;
+  }
+
+#define TCM_BASE 0x70000000
+
+#define MIN 16
+#define MAX 128
+#define STEP 16
+#define VL 16
+#define DL 8
+
+int main(void) {
+  size_t m = VL;
+  size_t n = VL;
+
+  // int8_t At[m*MAX];
+  // int8_t B[MAX*n];
+  int8_t* B = (int8_t*)TCM_BASE;
+  int8_t* At = (int8_t*)(TCM_BASE + n * MAX);
+  int32_t C_init[m*n];
+  int32_t C_bme[m*n];
+  // scalar copy of A, B
+  int32_t C_gold[m*n];
+  int8_t Ats[m*MAX];
+  int8_t Bs[MAX*n];
+  i8_init(At, m * MAX, 1);
+  i8_init(B, MAX * n, 2);
+  i8_init(Ats, m * MAX, 1);
+  i8_init(Bs, MAX * n, 2);
+  i32_init(C_init, m * n);
+  
+  printf("i8 GEMM\n");
+  printf("vlen = %d; dlen = %d\n", VL*8, DL*8);
+  printf("warmup cache:\n");
+  printf("dim,ops,cycles\n");
+  int64_t cyclest1 = read_csr(mcycle);
+  i8_mm_bme_square(C_init, C_bme, At, B, m, n, MAX);
+  asm volatile("fence");
+  int64_t cyclest2 = read_csr(mcycle);
+  int64_t cycles = cyclest2 - cyclest1;
+  int64_t ops = m * n * MAX;
+  // printf("%d,%ld,%ld\n", MAX, ops, cycles);
+  
+  for (size_t k = MIN; k <= MAX; k += STEP) {
+    // printf("Initializing M, N, K = %ld %ld %ld\n", m, n, k);
+    
+    i8_mm_scalar(C_init, C_gold, Ats, Bs, m, n, k);
+    // printf("\nTesting BME\n");
+    cyclest1 = read_csr(mcycle);
+    i8_mm_bme_square(C_init, C_bme, At, B, m, n, k);
+    asm volatile("fence");
+    cyclest2 = read_csr(mcycle);
+
+    // printf("C BME\n");
+    // print_matrix(C_bme, m, n);
+    cycles = cyclest2 - cyclest1;
+    ops = m * n * k;
+    printf("%ld,%ld,%ld\n", k, ops, cycles);
+        
+    int r = 0;      
+    r = i32_compare(C_bme, C_gold, m, n);
+    if (r) {
+        printf("Failure in BME M, N, K = %ld %ld %ld\n", m, n, k);
+        exit(1);
+    }
+    // printf("SUCCESS in BME M, N, K = %ld %ld %ld\n\n", m, n, k);
+  }
+  // printf("SUCCESS testing mmBME\n");
+  return 0;
+}

--- a/src/main/scala/common/Parameters.scala
+++ b/src/main/scala/common/Parameters.scala
@@ -52,7 +52,8 @@ object VectorParams {
   )
 
   def opuParams = genParams.copy(
-    vliqEntries = 6, // beef this up since OPU tends to be used with LMUL=1
+    vliqEntries = 8, // beef this up since OPU tends to be used with LMUL=1
+    vlissqEntries = 6,
     useOpu = true
   )
 


### PR DESCRIPTION
added square igemm performance benchmark.

changed queue depths in Parameters.scala
```
vliqEntries = 8, // beef this up since OPU tends to be used with LMUL=1
vlissqEntries = 6,
```
which allows op_macc valid signal to have no hiccups in inner loop.
before:
<img width="2069" alt="Screenshot 2025-05-06 at 1 15 11 PM" src="https://github.com/user-attachments/assets/95017f4f-0ce2-425f-a8d7-12d5aaeccb12" />
after:
<img width="2285" alt="Screenshot 2025-05-06 at 1 15 24 PM" src="https://github.com/user-attachments/assets/aca37592-43c1-45a0-82b7-1ef69ba5d7a5" />
